### PR TITLE
Improve performance of is_first_it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@ fn square_sum(n: u32) -> u32 {
 }
 
 fn is_unhappy(n:u32) -> bool {
-    let unhappy_markers: [u32; 8] = [89, 145, 42, 37, 58, 20, 4, 16];
-    return unhappy_markers.contains(&n)
+    const UNHAPPY_MARKERS: [u32; 8] = [89, 145, 42, 37, 58, 20, 4, 16];
+    return UNHAPPY_MARKERS.contains(&n)
 }
 
 pub fn is_happy(n: u32) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,15 @@
 
 fn square_sum(n: u32) -> u32 {
-    let n_string: String = n.to_string();
-    let mut ss: u32 = 0;
-
-    for c in n_string.chars() {
+    let digit_vec: Vec<u32> = n.to_string().chars().map(|c| {
         match c.to_digit(10) {
             Some(i) => {
-                ss += i.pow(2);
+                i.pow(2)
             },
-            _ => (),
+            _ => 0,
         }
-    }
+    }).collect();
 
-    return ss;
+    return digit_vec.iter().sum();
 }
 
 fn is_unhappy(n:u32) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,7 @@
 
 fn square_sum(n: u32) -> u32 {
     let digit_vec: Vec<u32> = n.to_string().chars().map(|c| {
-        match c.to_digit(10) {
-            Some(i) => {
-                i.pow(2)
-            },
-            _ => 0,
-        }
+        c.to_digit(10).unwrap().pow(2)
     }).collect();
 
     return digit_vec.iter().sum();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,18 +2,24 @@ extern crate happynum;
 
 use std::time::{Duration, Instant};
 
+fn is_sorted(v: Vec<u32>) -> bool {
+    for (i, n) in v.iter().enumerate() {
+        match v.get(&i -1) {
+            Some(prev) => {
+                if prev > n {
+                    return false;
+                }
+            },
+            _ => (),
+        }
+    }
+    return true;
+}
+
 fn is_first_it(n: u32) -> bool {
-    let mut digit_vec: Vec<u32> = n.to_string().chars()
+    let digit_vec: Vec<u32> = n.to_string().chars()
         .map(|s| s.to_digit(10).unwrap()).collect();
-    digit_vec.sort();
-
-    let sorted_n: u32 = {
-        let sorted_n_string: String = digit_vec.iter()
-            .map(|d| d.to_string()).collect();
-        sorted_n_string.parse::<u32>().unwrap()
-    };
-
-    return sorted_n == n;
+    return is_sorted(digit_vec);
 }
 
 fn main() {


### PR DESCRIPTION
Minor tidy up of square_sum
Set unhappy markers array into a constant to avoid unnecessary variable recreation
Check if digits are sorted in is_first_it instead of sorting the vec and recombining into an integer to compare with input